### PR TITLE
Remove unnecessary lines.

### DIFF
--- a/source/MenuState.hx
+++ b/source/MenuState.hx
@@ -17,7 +17,7 @@ class MenuState extends FlxState
 	 */
 	override public function create():Void
 	{
-		super.create();
+		
 	}
 	
 	/**

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -17,7 +17,7 @@ class PlayState extends FlxState
 	 */
 	override public function create():Void
 	{
-		super.create();
+		
 	}
 	
 	/**


### PR DESCRIPTION
 In both HaxeFlixel stable and dev, `super.create()` (i.e. `FlxState.create()`) is empty.